### PR TITLE
Refactor `EventStore`

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,16 @@ Next, clone `scdetect`:
 $ git clone https://github.com/damb/scdetect.git
 ```
 
+**Dependencies**:
+
+Besides of the [SeisComP core
+dependencies](https://github.com/SeisComP/seiscomp#prerequisites) the following
+packages must be installed to compile `scdetect`:
+
+- `libsqlite3-dev` (Debian, Ubuntu), `sqlite-devel` (RedHat, Fedora, CentOS),
+  `dev-db/sqlite` (Gentoo)
+
+
 For compiling SeisComP (including `scdetect`), please refer to
 https://github.com/SeisComP/seiscomp#build.
 

--- a/src/apps/scdetect/CMakeLists.txt
+++ b/src/apps/scdetect/CMakeLists.txt
@@ -5,6 +5,7 @@ set(
     app.cpp
     config.cpp
     datamodel/ddl.cpp
+    detail/sqlite.cpp
     detector.cpp
     detector/arrival.cpp
     detector/detector.cpp
@@ -32,6 +33,8 @@ endif()
 
 
 sc_add_executable(DETECT ${DETECT_TARGET})
+find_package(SQLite3 REQUIRED)
+target_link_libraries(${DETECT_TARGET} ${SQLITE3_LIBRARIES})
 sc_link_libraries_internal(${DETECT_TARGET} client)
 sc_install_init(${DETECT_TARGET}
   "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../base/common/apps/templates/initd.py")

--- a/src/apps/scdetect/CMakeLists.txt
+++ b/src/apps/scdetect/CMakeLists.txt
@@ -21,30 +21,6 @@ set(
     waveformprocessor.cpp
 )
 
-set(
-  DETECT_HEADERS
-    app.h
-    builder.h
-    config.h
-    datamodel/ddl.h
-    detector.h
-    detector/arrival.h
-    detector/detector.h
-    detector/linker.h
-    detector/pot.h
-    detector/template.h
-    eventstore.h
-    exception.h
-    log.h
-    processor.h
-    settings.h
-    utils.h
-    validators.h
-    version.h
-    waveform.h
-    waveformprocessor.h
-)
-
 # add_definitions(
 #   -DSCDETECT_DEBUG
 # )

--- a/src/apps/scdetect/CMakeLists.txt
+++ b/src/apps/scdetect/CMakeLists.txt
@@ -4,6 +4,7 @@ set(
   DETECT_SOURCES
     app.cpp
     config.cpp
+    datamodel/ddl.cpp
     detector.cpp
     detector/arrival.cpp
     detector/detector.cpp
@@ -25,6 +26,7 @@ set(
     app.h
     builder.h
     config.h
+    datamodel/ddl.h
     detector.h
     detector/arrival.h
     detector/detector.h

--- a/src/apps/scdetect/app.cpp
+++ b/src/apps/scdetect/app.cpp
@@ -575,7 +575,7 @@ bool Application::LoadEvents(const std::string &event_db,
       if (db) {
         SCDETECT_LOG_INFO("Connected successfully");
         auto query{utils::make_smart<DataModel::DatabaseQuery>(db.get())};
-        EventStore::Instance().Load(query);
+        EventStore::Instance().Load(query.get());
         loaded = true;
       } else {
         SCDETECT_LOG_WARNING("Database connection to %s failed",

--- a/src/apps/scdetect/app.cpp
+++ b/src/apps/scdetect/app.cpp
@@ -253,8 +253,17 @@ bool Application::init() {
         settings::kCacheRawWaveforms);
   }
 
+  // load event related data
+  if (!LoadEvents(config_.url_event_db, query())) {
+    SCDETECT_LOG_ERROR("Failed to load events");
+    return false;
+  }
+
   if (!InitDetectors(waveform_handler))
     return false;
+
+  // free memory after initialization
+  EventStore::Instance().Reset();
 
   output_origins_ = addOutputObjectLog("origin", primaryMessagingGroup());
 
@@ -262,11 +271,11 @@ bool Application::init() {
 }
 
 bool Application::run() {
-  SCDETECT_LOG_DEBUG("Application initialized.");
+  SCDETECT_LOG_DEBUG("Application initialized");
 
   if (config_.templates_prepare) {
     SCDETECT_LOG_DEBUG(
-        "Requested application exit after template initialization.");
+        "Requested application exit after template initialization");
     return true;
   }
 
@@ -593,17 +602,6 @@ bool Application::LoadEvents(const std::string &event_db,
 }
 
 bool Application::InitDetectors(WaveformHandlerIfacePtr waveform_handler) {
-
-  // load event related data
-  if (!LoadEvents(config_.url_event_db, query())) {
-    SCDETECT_LOG_ERROR("Failed to load events.");
-    return false;
-  }
-
-  if (!EventStore::Instance().event_parameters()) {
-    SCDETECT_LOG_ERROR("No event parameters found.");
-    return false;
-  }
 
   config_.path_filesystem_cache =
       boost::filesystem::path(config_.path_filesystem_cache).string();

--- a/src/apps/scdetect/app.h
+++ b/src/apps/scdetect/app.h
@@ -113,7 +113,7 @@ protected:
                      const WaveformProcessor::ResultCPtr &result);
 
 protected:
-  // Load events either from `event_db` or `db`.
+  // Load events either from `event_db` or `db`
   virtual bool LoadEvents(const std::string &event_db,
                           DataModel::DatabaseQueryPtr db);
 

--- a/src/apps/scdetect/datamodel/ddl.cpp
+++ b/src/apps/scdetect/datamodel/ddl.cpp
@@ -24,12 +24,13 @@ void createAll(IO::DatabaseInterface *dbDriver) {
 
   boost::filesystem::path pathDDL{"db"};
   const std::string className{dbDriver->className()};
-  if ("postgresql_database_interface" == className) {
+  if ("sqlite3_database_interface_" == className ||
+      "sqlite3_database_interface" == className) {
+    pathDDL /= "sqlite3.sql";
+  } else if ("postgresql_database_interface" == className) {
     pathDDL /= "postgresql.sql";
   } else if ("mysql_database_interface" == className) {
     pathDDL /= "mysql.sql";
-  } else if ("sqlite3_database_interface" == className) {
-    pathDDL /= "sqlite3.sql";
   } else {
     throw Core::ValueException("Unknown DB driver class name: " + className);
   }

--- a/src/apps/scdetect/datamodel/ddl.cpp
+++ b/src/apps/scdetect/datamodel/ddl.cpp
@@ -1,0 +1,85 @@
+#include "ddl.h"
+
+#include <algorithm>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#include <boost/algorithm/string/join.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/filesystem.hpp>
+
+#include <seiscomp/core/exceptions.h>
+#include <seiscomp/system/environment.h>
+
+namespace Seiscomp {
+namespace DataModel {
+
+void createAll(IO::DatabaseInterface *dbDriver) {
+  if (!dbDriver) {
+    return;
+  }
+
+  boost::filesystem::path pathDDL{"db"};
+  const std::string className{dbDriver->className()};
+  if ("postgresql_database_interface" == className) {
+    pathDDL /= "postgresql.sql";
+  } else if ("mysql_database_interface" == className) {
+    pathDDL /= "mysql.sql";
+  } else if ("sqlite3_database_interface" == className) {
+    pathDDL /= "sqlite3.sql";
+  } else {
+    throw Core::ValueException("Unknown DB driver class name: " + className);
+  }
+
+  std::vector<std::string> tokens;
+  int blockCounter{0};
+  auto processDDL = [&tokens, &blockCounter,
+                     &dbDriver](const std::string &line) {
+    tokens.push_back(line);
+
+    // check for blocks
+    std::vector<std::string> tmp;
+    boost::algorithm::find_all(tmp, line, "BEGIN");
+    blockCounter += tmp.size();
+    tmp.clear();
+    boost::algorithm::find_all(tmp, line, "END;");
+    blockCounter -= tmp.size();
+
+    if (blockCounter || line.back() != ';') {
+      return;
+    }
+
+    dbDriver->start();
+    dbDriver->execute(boost::algorithm::join(tokens, " ").c_str());
+    dbDriver->commit();
+    tokens.clear();
+  };
+
+  // read SQL DDL file
+  Environment *env{Environment::Instance()};
+  pathDDL = env->shareDir() / pathDDL;
+
+  std::ifstream ifs;
+  ifs.exceptions(std::ifstream::badbit); // No need to check failbit
+  try {
+    ifs.open(pathDDL.string());
+    std::string line;
+    while (std::getline(ifs, line)) {
+      boost::algorithm::trim(line);
+      if (!line.empty()) {
+        processDDL(line);
+      }
+    }
+  } catch (const std::ifstream::failure &e) {
+    throw Core::GeneralException{std::string{"Failed to open/read DDL file: "} +
+                                 e.what()};
+  }
+
+  ifs.close();
+}
+
+} // namespace DataModel
+} // namespace Seiscomp

--- a/src/apps/scdetect/datamodel/ddl.h
+++ b/src/apps/scdetect/datamodel/ddl.h
@@ -1,0 +1,15 @@
+#ifndef SCDETECT_APPS_SCDETECT_DATAMODEL_DDL_H_
+#define SCDETECT_APPS_SCDETECT_DATAMODEL_DDL_H_
+
+#include <seiscomp/io/database.h>
+
+namespace Seiscomp {
+namespace DataModel {
+
+// Create the database schema. Tables already present are dropped.
+void createAll(IO::DatabaseInterface *dbDriver);
+
+} // namespace DataModel
+} // namespace Seiscomp
+
+#endif // SCDETECT_APPS_SCDETECT_DATAMODEL_DDL_H_

--- a/src/apps/scdetect/detail/sqlite.cpp
+++ b/src/apps/scdetect/detail/sqlite.cpp
@@ -1,0 +1,239 @@
+/***************************************************************************
+ * Copyright (C) gempa GmbH                                                *
+ * All rights reserved.                                                    *
+ * Contact: gempa GmbH (seiscomp-dev@gempa.de)                             *
+ *                                                                         *
+ * Author: Jan Becker                                                      *
+ * Email: jabe@gempa.de                                                    *
+ *                                                                         *
+ * GNU Affero General Public License Usage                                 *
+ * This file may be used under the terms of the GNU Affero                 *
+ * Public License version 3.0 as published by the Free Software Foundation *
+ * and appearing in the file LICENSE included in the packaging of this     *
+ * file. Please review the following information to ensure the GNU Affero  *
+ * Public License version 3.0 requirements will be met:                    *
+ * https://www.gnu.org/licenses/agpl-3.0.html.                             *
+ *                                                                         *
+ * Other Usage                                                             *
+ * Alternatively, this file may be used in accordance with the terms and   *
+ * conditions contained in a signed written agreement between you and      *
+ * gempa GmbH.                                                             *
+ ***************************************************************************/
+
+#include "sqlite.h"
+
+#include <seiscomp/logging/log.h>
+#include <seiscomp/system/environment.h>
+
+#include <cstdio>
+#include <cstring>
+
+namespace Seiscomp {
+namespace detect {
+namespace detail {
+
+IMPLEMENT_SC_CLASS_DERIVED(SQLiteDatabase, Seiscomp::IO::DatabaseInterface,
+                           "sqlite3_database_interface_");
+
+REGISTER_DB_INTERFACE(SQLiteDatabase, "sqlite3_");
+
+SQLiteDatabase::SQLiteDatabase()
+    : _handle(NULL), _stmt(NULL), _columnCount(0) {}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+SQLiteDatabase::~SQLiteDatabase() { disconnect(); }
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool SQLiteDatabase::open() {
+  std::string uri(_host);
+  if (uri != ":memory:") {
+    uri = Environment::Instance()->absolutePath(_host);
+
+    FILE *fp = fopen(uri.c_str(), "rb");
+    if (fp == NULL) {
+      SEISCOMP_ERROR("databasefile '%s' not found", uri.c_str());
+      return false;
+    }
+    fclose(fp);
+  }
+
+  int res = sqlite3_open(uri.c_str(), &_handle);
+  if (res != SQLITE_OK) {
+    SEISCOMP_ERROR("sqlite3 open error: %d", res);
+    sqlite3_close(_handle);
+    return false;
+  }
+
+  return true;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool SQLiteDatabase::connect(const char *con) {
+  _host = con;
+  _columnPrefix = "";
+  return open();
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SQLiteDatabase::disconnect() {
+  if (_handle != NULL) {
+    sqlite3_close(_handle);
+    _handle = NULL;
+  }
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool SQLiteDatabase::isConnected() const { return _handle != NULL; }
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SQLiteDatabase::start() { execute("begin transaction"); }
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SQLiteDatabase::commit() { execute("commit transaction"); }
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SQLiteDatabase::rollback() { execute("rollback transaction"); }
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool SQLiteDatabase::execute(const char *command) {
+  if (!isConnected() || command == NULL)
+    return false;
+
+  char *errmsg = NULL;
+  int result = sqlite3_exec(_handle, command, NULL, NULL, &errmsg);
+  if (errmsg != NULL) {
+    SEISCOMP_ERROR("sqlite3 execute: %s", errmsg);
+    sqlite3_free(errmsg);
+  }
+
+  return result == SQLITE_OK;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool SQLiteDatabase::beginQuery(const char *query) {
+  if (!isConnected() || query == NULL)
+    return false;
+  if (_stmt) {
+    SEISCOMP_ERROR("beginQuery: nested queries are not supported");
+    return false;
+  }
+
+  const char *tail;
+  int res = sqlite3_prepare(_handle, query, -1, &_stmt, &tail);
+  if (res != SQLITE_OK)
+    return false;
+
+  if (_stmt == NULL)
+    return false;
+
+  _columnCount = sqlite3_column_count(_stmt);
+
+  return true;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+void SQLiteDatabase::endQuery() {
+  if (_stmt) {
+    sqlite3_finalize(_stmt);
+    _stmt = NULL;
+    _columnCount = 0;
+  }
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+const char *SQLiteDatabase::defaultValue() const { return "null"; }
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+IO::DatabaseInterface::OID SQLiteDatabase::lastInsertId(const char *) {
+  sqlite3_int64 id = sqlite3_last_insert_rowid(_handle);
+  return id <= 0 ? IO::DatabaseInterface::INVALID_OID : id;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+uint64_t SQLiteDatabase::numberOfAffectedRows() {
+  int count = sqlite3_changes(_handle);
+  if (count < 0)
+    return (uint64_t)~0;
+
+  return count;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool SQLiteDatabase::fetchRow() { return sqlite3_step(_stmt) == SQLITE_ROW; }
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+int SQLiteDatabase::findColumn(const char *name) {
+  for (int i = 0; i < _columnCount; ++i)
+    if (!strcmp(sqlite3_column_name(_stmt, i), name))
+      return i;
+
+  return -1;
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+int SQLiteDatabase::getRowFieldCount() const { return _columnCount; }
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+const char *SQLiteDatabase::getRowFieldName(int index) {
+  return sqlite3_column_name(_stmt, index);
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+const void *SQLiteDatabase::getRowField(int index) {
+  return sqlite3_column_blob(_stmt, index);
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+size_t SQLiteDatabase::getRowFieldSize(int index) {
+  return sqlite3_column_bytes(_stmt, index);
+}
+// <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+// >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+bool SQLiteDatabase::escape(std::string &out, const std::string &in) {
+  out.resize(in.size() * 2 + 1);
+  size_t length = in.length();
+  const char *in_buf = in.c_str();
+  char *out_buf = &out[0];
+  size_t j = 0;
+
+  for (size_t i = 0; i < length && *in_buf; ++length, ++in_buf) {
+    switch (*in_buf) {
+    case '\'':
+      out_buf[j++] = '\'';
+      out_buf[j++] = '\'';
+      break;
+    default:
+      out_buf[j++] = *in_buf;
+      break;
+    }
+  }
+
+  out_buf[j] = '\0';
+  out.resize(j);
+  return true;
+}
+
+} // namespace detail
+} // namespace detect
+} // namespace Seiscomp

--- a/src/apps/scdetect/detail/sqlite.h
+++ b/src/apps/scdetect/detail/sqlite.h
@@ -1,0 +1,91 @@
+/***************************************************************************
+ * Copyright (C) gempa GmbH                                                *
+ * All rights reserved.                                                    *
+ * Contact: gempa GmbH (seiscomp-dev@gempa.de)                             *
+ *                                                                         *
+ * Author: Jan Becker                                                      *
+ * Email: jabe@gempa.de                                                    *
+ *                                                                         *
+ * GNU Affero General Public License Usage                                 *
+ * This file may be used under the terms of the GNU Affero                 *
+ * Public License version 3.0 as published by the Free Software Foundation *
+ * and appearing in the file LICENSE included in the packaging of this     *
+ * file. Please review the following information to ensure the GNU Affero  *
+ * Public License version 3.0 requirements will be met:                    *
+ * https://www.gnu.org/licenses/agpl-3.0.html.                             *
+ *                                                                         *
+ * Other Usage                                                             *
+ * Alternatively, this file may be used in accordance with the terms and   *
+ * conditions contained in a signed written agreement between you and      *
+ * gempa GmbH.                                                             *
+ ***************************************************************************/
+
+#ifndef _SCDETECT_APPS_SCDETECT_DETAIL_SQLITE_H_
+#define _SCDETECT_APPS_SCDETECT_DETAIL_SQLITE_H_
+
+#include <sqlite3.h>
+
+#include <seiscomp/io/database.h>
+
+namespace Seiscomp {
+namespace detect {
+namespace detail {
+
+class SQLiteDatabase : public Seiscomp::IO::DatabaseInterface {
+  DECLARE_SC_CLASS(SQLiteDatabase);
+  // ------------------------------------------------------------------
+  //  Xstruction
+  // ------------------------------------------------------------------
+public:
+  SQLiteDatabase();
+  ~SQLiteDatabase();
+
+  // ------------------------------------------------------------------
+  //  Public interface
+  // ------------------------------------------------------------------
+public:
+  bool connect(const char *con) override;
+  void disconnect() override;
+
+  bool isConnected() const override;
+
+  void start() override;
+  void commit() override;
+  void rollback() override;
+
+  bool execute(const char *command) override;
+  bool beginQuery(const char *query) override;
+  void endQuery() override;
+
+  const char *defaultValue() const override;
+  OID lastInsertId(const char *) override;
+  uint64_t numberOfAffectedRows();
+
+  bool fetchRow() override;
+  int findColumn(const char *name) override;
+  int getRowFieldCount() const override;
+  const char *getRowFieldName(int index) override;
+  const void *getRowField(int index) override;
+  size_t getRowFieldSize(int index) override;
+  bool escape(std::string &out, const std::string &in) override;
+
+  // ------------------------------------------------------------------
+  //  Protected interface
+  // ------------------------------------------------------------------
+protected:
+  bool open();
+
+  // ------------------------------------------------------------------
+  //  Implementation
+  // ------------------------------------------------------------------
+private:
+  sqlite3 *_handle;
+  sqlite3_stmt *_stmt;
+  int _columnCount;
+};
+
+} // namespace detail
+} // namespace detect
+} // namespace Seiscomp
+
+#endif

--- a/src/apps/scdetect/eventstore.cpp
+++ b/src/apps/scdetect/eventstore.cpp
@@ -144,7 +144,7 @@ EventStore::LoadXMLArchive(const std::string &path) {
 IO::DatabaseInterfacePtr
 EventStore::CreateInMemoryDB(DataModel::EventParameters *ep) {
   IO::DatabaseInterfacePtr db_engine_write{
-      IO::DatabaseInterface::Open("sqlite3://:memory:")};
+      IO::DatabaseInterface::Open("sqlite3_://:memory:")};
   if (!db_engine_write) {
     throw EventStore::DatabaseException{
         "Failed to initialize SQLite in-memory DB"};

--- a/src/apps/scdetect/eventstore.cpp
+++ b/src/apps/scdetect/eventstore.cpp
@@ -1,18 +1,61 @@
 #include "eventstore.h"
 
+#include <vector>
+
 #include <seiscomp/datamodel/amplitude.h>
+#include <seiscomp/datamodel/databasearchive.h>
+#include <seiscomp/datamodel/databasequery.h>
 #include <seiscomp/datamodel/event.h>
 #include <seiscomp/datamodel/magnitude.h>
 #include <seiscomp/datamodel/origin.h>
 #include <seiscomp/datamodel/pick.h>
+#include <seiscomp/datamodel/publicobject.h>
 #include <seiscomp/io/archive/xmlarchive.h>
+#include <seiscomp/io/database.h>
 
+#include "datamodel/ddl.h"
 #include "log.h"
-#include "seiscomp/datamodel/amplitude.h"
-#include "seiscomp/datamodel/publicobject.h"
+#include "seiscomp/datamodel/databasequery.h"
+#include "utils.h"
 
 namespace Seiscomp {
 namespace detect {
+
+namespace detail {
+
+PublicObjectBuffer::PublicObjectBuffer() {}
+PublicObjectBuffer::PublicObjectBuffer(
+    DataModel::DatabaseArchive *archive,
+    const boost::optional<size_t> &buffer_size)
+    : PublicObjectCache{archive}, buffer_size_{buffer_size} {}
+
+void PublicObjectBuffer::set_buffer_size(
+    const boost::optional<size_t> &buffer_size) {
+  buffer_size_ = buffer_size;
+}
+
+boost::optional<size_t> PublicObjectBuffer::buffer_size() const {
+  return buffer_size_;
+}
+
+bool PublicObjectBuffer::feed(DataModel::PublicObject *po) {
+  push(po);
+  if (buffer_size_) {
+    while (size() > buffer_size_)
+      pop();
+  }
+  return true;
+}
+
+} // namespace detail
+
+const int EventStore::buffer_size_{25000};
+
+EventStore::BaseException::BaseException()
+    : Exception{"base EventStore exception"} {}
+EventStore::SCMLException::SCMLException() : BaseException{"SCML exception"} {}
+EventStore::DatabaseException::DatabaseException()
+    : BaseException{"database exception"} {}
 
 EventStore &EventStore::Instance() {
   // guaranteed to be destroyed; instantiated on first use
@@ -21,127 +64,88 @@ EventStore &EventStore::Instance() {
 }
 
 void EventStore::Load(const std::string &path) {
+  DataModel::EventParametersPtr ep;
+  LoadXMLArchive(path, ep);
+  Load(ep);
+}
+void EventStore::Load(const boost::filesystem::path &path) {
+  Instance().Load(path.string());
+}
+
+void EventStore::Load(DataModel::EventParametersPtr &ep) {
+  auto db_query{CreateInMemoryDB(ep)};
+  Load(db_query);
+}
+
+void EventStore::Load(DataModel::DatabaseQueryPtr db) {
+  Reset();
+  cache_.setDatabaseArchive(db.get());
+  db_ = db;
+}
+
+void EventStore::Reset() {
+  cache_.clear();
+  cache_.setDatabaseArchive(nullptr);
+  db_.reset();
+}
+
+DataModel::EventPtr EventStore::GetEvent(const std::string &origin_id) const {
+  auto event{db_->getEvent(origin_id)};
+  if (event) {
+    cache_.feed(event);
+    return event;
+  }
+  return nullptr;
+}
+
+DataModel::PublicObject *EventStore::Get(const Core::RTTI &class_type,
+                                         const std::string &public_id) const {
+  auto retval{cache_.find(class_type, public_id)};
+  if (retval) {
+    return retval;
+  }
+  return nullptr;
+}
+
+DataModel::PublicObject *
+EventStore::GetWithChildren(const Core::RTTI &class_type,
+                            const std::string &public_id) const {
+  auto retval{db_->loadObject(class_type, public_id)};
+  if (retval) {
+    // XXX(damb): Currently, the requested object is cached, only. That is,
+    // children are not fed.
+    cache_.feed(retval);
+    return retval;
+  }
+  return nullptr;
+}
+
+void EventStore::LoadXMLArchive(const std::string &path,
+                                DataModel::EventParametersPtr &ep) {
   if (!path.empty()) {
     IO::XMLArchive ar;
     if (!ar.open(path.c_str())) {
       throw SCMLException{std::string("Failed to open file: ") + path};
     }
-    ar >> event_parameters_;
+    ar >> ep;
     ar.close();
   }
-
-  cache_.clear();
-  // populate cache
-  if (!set_cache(event_parameters_)) {
-    cache_.clear();
-  }
 }
 
-void EventStore::Load(const boost::filesystem::path &path) {
-  Load(path.string());
-}
-
-void EventStore::Load(DataModel::EventParametersPtr ep) {
-  event_parameters_ = ep;
-
-  cache_.clear();
-  // populate cache
-  if (!set_cache(event_parameters_)) {
-    cache_.clear();
+DataModel::DatabaseQueryPtr
+EventStore::CreateInMemoryDB(DataModel::EventParametersPtr &ep) {
+  IO::DatabaseInterfacePtr db_engine{
+      IO::DatabaseInterface::Open("sqlite3://:memory:")};
+  if (!db_engine) {
+    throw EventStore::DatabaseException{
+        "Failed to initialize SQLite in-memory DB"};
   }
-}
+  DataModel::createAll(db_engine.get());
+  DataModel::DatabaseArchive db_archive{db_engine.get()};
+  DataModel::DatabaseObjectWriter writer{db_archive};
 
-void EventStore::Load(DataModel::DatabaseReaderPtr db) {
-
-  if (db) {
-    event_parameters_ = db->loadEventParameters();
-  }
-
-  cache_.clear();
-  // populate cache
-  if (!set_cache(event_parameters_)) {
-    cache_.clear();
-  }
-}
-
-void EventStore::Reset() {
-  event_parameters_.reset();
-  cache_.clear();
-}
-
-EventStore::SCMLException::SCMLException() : Exception{"SCML exception"} {}
-
-DataModel::EventParametersCPtr EventStore::event_parameters() const {
-  return event_parameters_;
-}
-
-bool EventStore::set_cache(DataModel::EventParametersPtr ep) {
-  if (!ep || !cache_.feed(ep.get()))
-    return false;
-
-  // load events
-  for (size_t i = 0; i < ep->eventCount(); ++i) {
-    if (!cache_.feed(ep->event(i))) {
-      return false;
-    }
-  }
-
-  // load origins
-  for (size_t i = 0; i < ep->originCount(); ++i) {
-
-    DataModel::Origin *origin{ep->origin(i)};
-    if (!cache_.feed(origin)) {
-      return false;
-    }
-
-    // load magnitudes
-    for (size_t j = 0; j < origin->magnitudeCount(); ++j) {
-      if (!cache_.feed(origin->magnitude(j))) {
-        return false;
-      }
-    }
-  }
-
-  // load picks
-  for (size_t i = 0; i < ep->pickCount(); ++i) {
-    if (!cache_.feed(ep->pick(i))) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-DataModel::PublicObject *EventStore::Get(const Core::RTTI &class_type,
-                                         const std::string &public_id) {
-
-  auto retval = cache_.find(class_type, public_id);
-  if (retval) {
-    return retval;
-  }
-
-  if (event_parameters_) {
-    if (DataModel::Pick::TypeInfo() == class_type) {
-      return event_parameters_->findPick(public_id);
-    } else if (DataModel::Event::TypeInfo() == class_type) {
-      return event_parameters_->findEvent(public_id);
-    } else if (DataModel::Origin::TypeInfo() == class_type) {
-      return event_parameters_->findOrigin(public_id);
-    } else if (DataModel::Amplitude::TypeInfo() == class_type) {
-      return event_parameters_->findAmplitude(public_id);
-    } else if (DataModel::Magnitude::TypeInfo() == class_type) {
-      // linear search
-      for (size_t i = 0; i < event_parameters_->originCount(); ++i) {
-        auto origin = event_parameters_->origin(i);
-        for (size_t j = 0; j < origin->magnitudeCount(); ++j) {
-          if (origin->magnitude(j)->publicID() == public_id) {
-            return origin->magnitude(j);
-          }
-        }
-      }
-    }
-  }
-  return nullptr;
+  writer(ep.get());
+  return utils::make_smart<DataModel::DatabaseQuery>(db_engine.get());
 }
 
 } // namespace detect

--- a/src/apps/scdetect/eventstore.h
+++ b/src/apps/scdetect/eventstore.h
@@ -1,10 +1,15 @@
 #ifndef SCDETECT_APPS_SCDETECT_EVENTSTORE_H_
 #define SCDETECT_APPS_SCDETECT_EVENTSTORE_H_
 
+#include <string>
+#include <vector>
+
 #include <boost/filesystem.hpp>
+#include <boost/optional.hpp>
 
 #include <seiscomp/core/defs.h>
-#include <seiscomp/datamodel/databasereader.h>
+#include <seiscomp/datamodel/databasequery.h>
+#include <seiscomp/datamodel/event.h>
 #include <seiscomp/datamodel/eventparameters.h>
 #include <seiscomp/datamodel/publicobjectcache.h>
 
@@ -13,10 +18,44 @@
 namespace Seiscomp {
 namespace detect {
 
-// Implements the Singleton Design Pattern
-class EventStore {
-
+namespace detail {
+class PublicObjectBuffer : public DataModel::PublicObjectCache {
 public:
+  PublicObjectBuffer();
+  PublicObjectBuffer(DataModel::DatabaseArchive *archive,
+                     const boost::optional<size_t> &buffer_size);
+
+  void set_buffer_size(const boost::optional<size_t> &buffer_size);
+  boost::optional<size_t> buffer_size() const;
+
+  bool feed(DataModel::PublicObject *po) override;
+
+private:
+  boost::optional<size_t> buffer_size_;
+};
+
+} // namespace detail
+
+class EventStore {
+public:
+  class BaseException : public Exception {
+  public:
+    using Exception::Exception;
+    BaseException();
+  };
+
+  class SCMLException : public BaseException {
+  public:
+    using BaseException::BaseException;
+    SCMLException();
+  };
+
+  class DatabaseException : public BaseException {
+  public:
+    using BaseException::BaseException;
+    DatabaseException();
+  };
+
   template <typename T>
   using SmartPointer = typename Core::SmartPointer<T>::Impl;
 
@@ -27,36 +66,49 @@ public:
 
   void Load(const std::string &path);
   void Load(const boost::filesystem::path &path);
-  void Load(DataModel::EventParametersPtr ep);
-  void Load(DataModel::DatabaseReaderPtr db);
+  void Load(DataModel::EventParametersPtr &ep);
+  void Load(DataModel::DatabaseQueryPtr db);
 
   // Reset the store
   void Reset();
 
-  DataModel::EventParametersCPtr event_parameters() const;
-
-  template <typename T> SmartPointer<T> Get(const std::string &public_id) {
+  // Returns the requested object specified by `public_id` (excluding
+  // descendants)
+  template <typename T>
+  SmartPointer<T> Get(const std::string &public_id) const {
     return T::Cast(Get(T::TypeInfo(), public_id));
   }
 
-  class SCMLException : public Exception {
-  public:
-    using Exception::Exception;
-    SCMLException();
-  };
+  // Returns the requested object specified by `public_id` (including
+  // descendants)
+  template <typename T>
+  SmartPointer<T> GetWithChildren(const std::string &public_id) const {
+    return T::Cast(GetWithChildren(T::TypeInfo(), public_id));
+  }
+
+  // Returns the event for a given `origin_id` if any
+  DataModel::EventPtr GetEvent(const std::string &origin_id) const;
 
 protected:
-  // Populate the cache from event parameters.
-  virtual bool set_cache(DataModel::EventParametersPtr ep);
-
   DataModel::PublicObject *Get(const Core::RTTI &class_type,
-                               const std::string &public_id);
+                               const std::string &public_id) const;
+  DataModel::PublicObject *GetWithChildren(const Core::RTTI &class_type,
+                                           const std::string &public_id) const;
+
+  void LoadXMLArchive(const std::string &path,
+                      DataModel::EventParametersPtr &ep);
+
+  // Create an in-memory DB populated with `ep`
+  DataModel::DatabaseQueryPtr
+  CreateInMemoryDB(DataModel::EventParametersPtr &ep);
 
 private:
   EventStore() {}
 
-  DataModel::EventParametersPtr event_parameters_;
-  DataModel::PublicObjectTimeSpanBuffer cache_;
+  DataModel::DatabaseQueryPtr db_;
+  mutable detail::PublicObjectBuffer cache_;
+
+  static const int buffer_size_;
 };
 
 } // namespace detect

--- a/src/apps/scdetect/eventstore.h
+++ b/src/apps/scdetect/eventstore.h
@@ -14,6 +14,7 @@
 #include <seiscomp/datamodel/eventparameters.h>
 #include <seiscomp/datamodel/publicobject.h>
 #include <seiscomp/datamodel/publicobjectcache.h>
+#include <seiscomp/io/database.h>
 
 #include "exception.h"
 
@@ -71,8 +72,8 @@ public:
 
   void Load(const std::string &path);
   void Load(const boost::filesystem::path &path);
-  void Load(DataModel::EventParametersPtr &ep);
-  void Load(DataModel::DatabaseQueryPtr db);
+  void Load(DataModel::EventParameters *ep);
+  void Load(DataModel::DatabaseQuery *db);
 
   // Reset the store
   void Reset();
@@ -99,17 +100,16 @@ protected:
                                const std::string &public_id,
                                bool loadChildren = false) const;
 
-  void LoadXMLArchive(const std::string &path,
-                      DataModel::EventParametersPtr &ep);
+  DataModel::EventParametersPtr LoadXMLArchive(const std::string &path);
 
-  // Create an in-memory DB populated with `ep`
-  DataModel::DatabaseQueryPtr
-  CreateInMemoryDB(DataModel::EventParametersPtr &ep);
+  // Create an in-memory SQLite DB populated with `ep` and return the
+  // corresponding pointer to the database engine created
+  IO::DatabaseInterfacePtr CreateInMemoryDB(DataModel::EventParameters *ep);
 
 private:
   EventStore() {}
 
-  DataModel::DatabaseQueryPtr db_;
+  DataModel::DatabaseQueryPtr db_query_;
   mutable detail::PublicObjectBuffer cache_;
 
   static const int buffer_size_;

--- a/src/apps/scdetect/eventstore.h
+++ b/src/apps/scdetect/eventstore.h
@@ -9,8 +9,10 @@
 
 #include <seiscomp/core/defs.h>
 #include <seiscomp/datamodel/databasequery.h>
+#include <seiscomp/datamodel/databasereader.h>
 #include <seiscomp/datamodel/event.h>
 #include <seiscomp/datamodel/eventparameters.h>
+#include <seiscomp/datamodel/publicobject.h>
 #include <seiscomp/datamodel/publicobjectcache.h>
 
 #include "exception.h"
@@ -22,13 +24,16 @@ namespace detail {
 class PublicObjectBuffer : public DataModel::PublicObjectCache {
 public:
   PublicObjectBuffer();
-  PublicObjectBuffer(DataModel::DatabaseArchive *archive,
+  PublicObjectBuffer(DataModel::DatabaseReader *archive,
                      const boost::optional<size_t> &buffer_size);
 
   void set_buffer_size(const boost::optional<size_t> &buffer_size);
   boost::optional<size_t> buffer_size() const;
 
   bool feed(DataModel::PublicObject *po) override;
+
+  DataModel::PublicObject *find(const Core::RTTI &classType,
+                                const std::string &publicID, bool loadChildren);
 
 private:
   boost::optional<size_t> buffer_size_;
@@ -83,7 +88,7 @@ public:
   // descendants)
   template <typename T>
   SmartPointer<T> GetWithChildren(const std::string &public_id) const {
-    return T::Cast(GetWithChildren(T::TypeInfo(), public_id));
+    return T::Cast(Get(T::TypeInfo(), public_id, true));
   }
 
   // Returns the event for a given `origin_id` if any
@@ -91,9 +96,8 @@ public:
 
 protected:
   DataModel::PublicObject *Get(const Core::RTTI &class_type,
-                               const std::string &public_id) const;
-  DataModel::PublicObject *GetWithChildren(const Core::RTTI &class_type,
-                                           const std::string &public_id) const;
+                               const std::string &public_id,
+                               bool loadChildren = false) const;
 
   void LoadXMLArchive(const std::string &path,
                       DataModel::EventParametersPtr &ep);

--- a/src/apps/scdetect/test/CMakeLists.txt
+++ b/src/apps/scdetect/test/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCES_integration
   ../app.cpp
   ../builder.cpp
   ../config.cpp
+  ../datamodel/ddl.cpp
   ../detector.cpp
   ../detector/arrival.cpp
   ../detector/detector.cpp

--- a/src/apps/scdetect/test/CMakeLists.txt
+++ b/src/apps/scdetect/test/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SOURCES_integration
   ../builder.cpp
   ../config.cpp
   ../datamodel/ddl.cpp
+  ../detail/sqlite.cpp
   ../detector.cpp
   ../detector/arrival.cpp
   ../detector/detector.cpp
@@ -48,6 +49,7 @@ foreach(TEST_SRC ${TESTS})
   add_executable(${TEST_TARGET} ${TEST_SRC} ${SOURCES_${TEST_FNAME}})
 	sc_link_libraries_internal(${TEST_TARGET} unittest core client)
 	sc_link_libraries(${TEST_TARGET} ${Boost_unit_test_framework_LIBRARY})
+  target_link_libraries(${TEST_TARGET} ${SQLITE3_LIBRARIES})
 
 	add_test(
 		NAME ${TEST_TARGET}


### PR DESCRIPTION
**Features and Changes**:
- Do not load all `EventParameters` from the database. Load only the required information in order to speed up the module initialization procedure.
- Refactor `EventStore` i.e. import `EventParameters` into an in-memory SQLite DB in order to make use of `Seiscomp::DataModel` facilities. (This approach introduces a hard dependency to [SQLite](https://www.sqlite.org/index.html).)