### PR TITLE
Catch builder::NoBindings exception

### DIFF
--- a/src/apps/scdetect/app.cpp
+++ b/src/apps/scdetect/app.cpp
@@ -1443,7 +1443,8 @@ bool Application::initTemplateFamilies(std::ifstream &ifs,
           SCDETECT_LOG_DEBUG("%s", logging::to_string(msg).c_str());
         } else {
           msg.setText(
-              "Missing template family members. Skipping registration.");
+              "Missing template family members. Skipping template family "
+              "registration.");
           SCDETECT_LOG_WARNING("%s", logging::to_string(msg).c_str());
         }
 
@@ -1463,6 +1464,13 @@ bool Application::initTemplateFamilies(std::ifstream &ifs,
         throw;
       } catch (builder::NoPick &e) {
         if (_config.skipReferenceConfigIfNoPick) {
+          SCDETECT_LOG_WARNING("%s. Skipping template family initialization.",
+                               e.what());
+          continue;
+        }
+        throw;
+      } catch (builder::NoBindings &e) {
+        if (_config.skipReferenceConfigIfNoBindings) {
           SCDETECT_LOG_WARNING("%s. Skipping template family initialization.",
                                e.what());
           continue;

--- a/src/apps/scdetect/app.h
+++ b/src/apps/scdetect/app.h
@@ -124,6 +124,12 @@ class Application : public Client::StreamApplication {
     // XXX(damb): For the time being, this configuration parameter is not
     // provided to module users.
     bool skipReferenceConfigIfNoPick{true};
+    // Defines if a template family should be initialized although reference
+    // configurations could not be initialized due to missing bindings
+    // configuration.
+    // XXX(damb): For the time being, this configuration parameter is not
+    // provided to module users.
+    bool skipReferenceConfigIfNoBindings{true};
 
     // Input
     std::string pathTemplateJson;


### PR DESCRIPTION
Handle this kind of exception properly. It shouldn't bubble up to the user.