### PR TITLE
Allow wildcard characters in bindings configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,11 +526,19 @@ frontend [scconfig](https://www.seiscomp.de/doc/base/concepts/configuration.html
    **Tip**: Although not strictly required, it is recommended to use sensible
    profile names. E.g. for a sensor location profile with `locationCode` `00`
    and `channelCode` `HH` naming the profile with e.g. `00_HH` is recommended.
-2. Add the profile's name to the list of known `sensorLocationProfiles`. Only
+
+   In both the `locationCode` and the `channelCode` the wildcard
+   characters `?` (which matches any single character) and `*` (which matches
+   zero to many characters) are allowed.
+
+   **Tip**: Make use of wildcard characters in order to create a *default*
+   sensor location profile.
+
+3. Add the profile's name to the list of known `sensorLocationProfiles`. Only
    those profiles are taken into account with a corresponding list entry.
-3. (Optional): in case of creating a *binding profile* assign the bindings
+4. (Optional): in case of creating a *binding profile* assign the bindings
    configuration to the corresponding stations.
-4. Save the configuration. With that, the bindings configuration is written to
+5. Save the configuration. With that, the bindings configuration is written to
    so called *key files*.
 
 **Dump bindings configurations**:

--- a/src/apps/scdetect/binding.h
+++ b/src/apps/scdetect/binding.h
@@ -88,6 +88,8 @@ struct SensorLocationConfig {
   // Returns the Stream configuration for `chaCode`
   const StreamConfig &at(const std::string &chaCode) const;
 
+  const StreamConfig &matchWildcards(const std::string &chaCode) const;
+
   using StreamConfigs = std::unordered_map<std::string, StreamConfig>;
   StreamConfigs streamConfigs;
 
@@ -116,6 +118,9 @@ class StationConfig {
                                  const std::string &chaCode) const;
 
  private:
+  const SensorLocationConfig &matchWildcards(const std::string &locCode,
+                                             const std::string &chaCode) const;
+
   ConfigMap _sensorLocationConfigs;
 
   Util::KeyValuesCPtr _parameters;
@@ -134,6 +139,10 @@ class Bindings {
   using ConfigMap = std::map<Key, StationConfig>;
 
  public:
+  // Generic wildcard character for binding association
+  static const char wildcardZeroToManyChar;
+  static const char wildcardSingleChar;
+
   using const_iterator = ConfigMap::const_iterator;
 
   const_iterator begin() const;
@@ -260,6 +269,10 @@ void load(const Processing::Settings &settings,
           SensorLocationConfig::MagnitudeProcessingConfig &storageLocation,
           const SensorLocationConfig::MagnitudeProcessingConfig &defaults);
 void validate(SensorLocationConfig &config);
+
+std::string removeDuplicateChar(const std::string &str, char c);
+
+void replaceWildcardChars(std::string &str);
 
 }  // namespace detail
 


### PR DESCRIPTION
**Feature and changes**:
- Allow wildcard characters in both the `locationCode` and `channelCode` to be defined. Allow users to define a *default* sensor location profile.



Closes: #52 