### PR TITLE
Monitor object throughput

### DIFF
--- a/src/apps/cc/app.cpp
+++ b/src/apps/cc/app.cpp
@@ -53,7 +53,6 @@
 #include "processing/timewindow_processor.h"
 #include "processing/waveform_processor.h"
 #include "resamplerstore.h"
-#include "settings.h"
 #include "util/horizontal_components.h"
 #include "util/memory.h"
 #include "util/util.h"
@@ -159,6 +158,20 @@ void Application::createCommandLineDescription() {
       "enables/disables the calculation of magnitudes regardless of the "
       "configuration provided on detector configuration level granularity",
       &_config.magnitudesForceMode, false);
+
+  commandline().addGroup("Monitor");
+  commandline().addOption(
+      "Monitor", "monitor-throughput-info-threshold",
+      "object throughput threshold for logging messages with level INFO",
+      &_config.objectThroughputInfoThreshold, false);
+  commandline().addOption(
+      "Monitor", "monitor-throughput-warning-threshold",
+      "object throughput threshold for logging messages with level WARNING",
+      &_config.objectThroughputWarningThreshold, false);
+  commandline().addOption(
+      "Monitor", "monitor-throughput-log-interval",
+      "log message interval in seconds for object throughput monitoring",
+      &_config.objectThroughputNofificationInterval, false);
 
   commandline().addGroup("Input");
   commandline().addOption(
@@ -271,6 +284,25 @@ bool Application::validateParameters() {
     return false;
   }
 
+  if (_config.objectThroughputInfoThreshold &&
+      _config.objectThroughputWarningThreshold &&
+      *_config.objectThroughputInfoThreshold <
+          *_config.objectThroughputWarningThreshold) {
+    SCDETECT_LOG_ERROR(
+        "Invalid configuration: 'monitor-throughput-info-threshold' < "
+        "'monitor-throughput-warning-threshold': %lu < %lu",
+        *_config.objectThroughputInfoThreshold,
+        *_config.objectThroughputWarningThreshold);
+    return false;
+  }
+  if (_config.objectThroughputNofificationInterval &&
+      *_config.objectThroughputNofificationInterval < 1) {
+    SCDETECT_LOG_ERROR(
+        "Invalid configuration: 'monitor-throughput-log-interval': %lu < 1",
+        *_config.objectThroughputNofificationInterval);
+    return false;
+  }
+
   return true;
 }
 
@@ -323,6 +355,10 @@ bool Application::initConfiguration() {
 
 bool Application::init() {
   if (!StreamApplication::init()) return false;
+
+  if (_config.objectThroughputNofificationInterval) {
+    enableTimer(*_config.objectThroughputNofificationInterval);
+  }
 
   _outputOrigins = addOutputObjectLog("origin", primaryMessagingGroup());
   _outputAmplitudes =
@@ -478,6 +514,50 @@ void Application::done() {
   MagnitudeProcessor::Factory::reset();
 
   StreamApplication::done();
+}
+
+bool Application::dispatch(Core::BaseObject *obj) {
+  // XXX(damb): except of the status messages all objects should be records and
+  // thus the actual record throughput is monitored
+  _averageObjectThroughputMonitor.push(Core::Time::GMT(), 1);
+  return Client::StreamApplication::dispatch(obj);
+}
+
+void Application::handleTimeout() {
+  auto runningMean{_averageObjectThroughputMonitor.value(Core::Time::GMT())};
+  std::string msg{"Current object throughput per second (averaged): " +
+                  std::to_string(runningMean)};
+
+  bool levelInfo{false};
+  bool levelWarning{false};
+  if (_config.objectThroughputInfoThreshold &&
+      _config.objectThroughputWarningThreshold) {
+    if (runningMean <= *_config.objectThroughputInfoThreshold) {
+      if (runningMean <= *_config.objectThroughputWarningThreshold) {
+        levelWarning = true;
+      } else {
+        levelInfo = true;
+      }
+    } else if (_config.objectThroughputInfoThreshold &&
+               !_config.objectThroughputWarningThreshold) {
+      if (runningMean <= *_config.objectThroughputInfoThreshold) {
+        levelInfo = true;
+      }
+    } else if (_config.objectThroughputWarningThreshold &&
+               !_config.objectThroughputInfoThreshold) {
+      if (runningMean <= *_config.objectThroughputInfoThreshold) {
+        levelWarning = true;
+      }
+    }
+
+    if (levelWarning) {
+      SCDETECT_LOG_WARNING("%s", msg.c_str());
+    } else if (levelInfo) {
+      SCDETECT_LOG_INFO("%s", msg.c_str());
+    } else {
+      SCDETECT_LOG_DEBUG("%s", msg.c_str());
+    }
+  }
 }
 
 void Application::handleRecord(Record *rec) {
@@ -817,9 +897,9 @@ void Application::processDetection(
   if (amplitudeForcedEnabled ||
       (!amplitudeForcedDisabled && detection->publishConfig.createAmplitudes)) {
     // XXX(damb): as soon as either amplitudes or magnitudes need to be
-    // computed, the detection is issued as a wholesale due to simplicity. (Note
-    // that the amplitudes could be issued independently from the origin while
-    // magnitudes need to be associated to the origin.)
+    // computed, the detection is issued as a wholesale due to simplicity.
+    // (Note that the amplitudes could be issued independently from the origin
+    // while magnitudes need to be associated to the origin.)
     auto detectionItemPtr{
         std::make_shared<DetectionItem>(std::move(detectionItem))};
     registerDetection(detectionItemPtr);

--- a/src/apps/cc/app.cpp
+++ b/src/apps/cc/app.cpp
@@ -603,10 +603,6 @@ void Application::handleRecord(Record *rec) {
   }
 }
 
-bool Application::isEventDatabaseEnabled() const {
-  return _config.urlEventDb.empty();
-}
-
 void Application::processDetection(
     const detector::DetectorWaveformProcessor *processor, const Record *record,
     const detector::DetectorWaveformProcessor::DetectionCPtr &detection) {
@@ -1192,6 +1188,10 @@ bool Application::initTemplateFamilies(std::ifstream &ifs,
     return false;
   }
   return true;
+}
+
+bool Application::isEventDatabaseEnabled() const {
+  return _config.urlEventDb.empty();
 }
 
 bool Application::loadEvents(const std::string &eventDb,

--- a/src/apps/cc/app.h
+++ b/src/apps/cc/app.h
@@ -184,7 +184,6 @@ class Application : public Client::StreamApplication {
 
   void handleRecord(Record *rec) override;
 
-  bool isEventDatabaseEnabled() const;
 
  private:
   using Picks = std::vector<DataModel::PickCPtr>;
@@ -282,6 +281,8 @@ class Application : public Client::StreamApplication {
                                    const TemplateConfigs &templateConfigs,
                                    const binding::Bindings &bindings,
                                    const Config &appConfig);
+
+  bool isEventDatabaseEnabled() const;
 
   // Load events either from `eventDb` or `db`
   bool loadEvents(const std::string &eventDb, DataModel::DatabaseQueryPtr db);

--- a/src/apps/cc/descriptions/scdetect-cc.xml
+++ b/src/apps/cc/descriptions/scdetect-cc.xml
@@ -332,6 +332,24 @@
         </option>
       </group>
 
+      <group name="Monitor">
+        <option flag="" long-flag="monitor-throughput-info-threshold">
+          <description>
+            Object throughput threshold for logging messages with level INFO.
+          </description>
+        </option>
+        <option flag="" long-flag="monitor-throughput-warning-threshold">
+          <description>
+            Object throughput threshold for logging messages with level WARNING.
+          </description>
+        </option>
+        <option flag="" long-flag="monitor-throughput-log-interval">
+          <description>
+            Log message interval in seconds for object throughput monitoring.
+          </description>
+        </option>
+      </group>
+
       <group name="Input">
         <option flag="" long-flag="templates-json">
           <description>

--- a/src/apps/cc/settings.h
+++ b/src/apps/cc/settings.h
@@ -40,6 +40,8 @@ const std::vector<std::string> kValidPrioritizedStationMagnitudeTypes{"MLhc",
 constexpr bool kCacheRawWaveforms{true};
 constexpr double kTemplateWaveformResampleMargin{2};
 
+constexpr int kObjectThroughputAverageTimeSpan{10};
+
 }  // namespace settings
 }  // namespace detect
 }  // namespace Seiscomp


### PR DESCRIPTION
**Feature and Changes**:
- Optionally allow to both monitor and log the module's object throughput. Since `scdetect-cc` is a stream application which in general does not need to subscribe and process messages from the SeisComP messaging system, the object throughput is a good approximation for the actual record throughput. Note that when measuring the throughput small errors may be introduced due to status messages (which generally can be neglected).
- Introduce the CLI flags:
  - `--monitor-throughput-log-interval`
  - `--monitor-throughput-info-threshold`
  - `--monitor-throughput-info-threshold`

Closes #80.