### PR TITLE
Allow to configure the waveform buffer size

### DIFF
--- a/src/apps/cc/amplitude/factory.cpp
+++ b/src/apps/cc/amplitude/factory.cpp
@@ -95,9 +95,9 @@ std::unique_ptr<AmplitudeProcessor> createMLx(
       msg.setText(e.what());
       throw Factory::BaseException{logging::to_string(msg)};
     }
-    msg.setText(
-        "Configured amplitude processor filter: filter=\"" + filter +
-        "init_time=" + std::to_string(amplitudeProcessingConfig.mlx.initTime));
+    msg.setText("Configured amplitude processor filter: filter=\"" + filter +
+                "\", init_time=" +
+                std::to_string(amplitudeProcessingConfig.mlx.initTime));
     SCDETECT_LOG_DEBUG_TAGGED(ret->id(), "%s", logging::to_string(msg).c_str());
   } else {
     msg.setText("Configured amplitude processor without filter: filter=\"\"");

--- a/src/apps/cc/app.cpp
+++ b/src/apps/cc/app.cpp
@@ -244,12 +244,19 @@ bool Application::validateParameters() {
     }
   }
   if (!util::isGeZero(_config.streamConfig.initTime)) {
+    SCDETECT_LOG_ERROR("Invalid configuration: 'initTime': %f. Must be >= 0.",
+                       _config.streamConfig.initTime);
+    return false;
+  }
+
+  if (_config.forcedWaveformBufferSize &&
+      !util::isGeZero(*_config.forcedWaveformBufferSize)) {
     SCDETECT_LOG_ERROR(
-        "Invalid configuration: 'initTime': %f. Must be "
-        "greater equal 0.",
+        "Invalid configuration: 'waveformBufferSize': %f. Must be >= 0.",
         _config.streamConfig.initTime);
     return false;
   }
+
   if (!config::validateArrivalOffsetThreshold(
           _config.detectorConfig.arrivalOffsetThreshold)) {
     SCDETECT_LOG_ERROR(
@@ -431,6 +438,14 @@ bool Application::init() {
   }
 
   initAmplitudeProcessorFactory();
+
+  try {
+    _waveformBuffer.setTimeSpan(
+        computeWaveformBufferSize(templateConfigs, _bindings, _config));
+  } catch (const ConfigError &e) {
+    SCDETECT_LOG_ERROR("Failed to configure waveform buffer: %s", e.what());
+    return false;
+  }
 
   bool magnitudesForcedDisabled{_config.magnitudesForceMode &&
                                 !*_config.magnitudesForceMode};
@@ -1273,6 +1288,31 @@ bool Application::initTemplateFamilies(std::ifstream &ifs,
   return true;
 }
 
+Core::TimeSpan Application::computeWaveformBufferSize(
+    const TemplateConfigs &templateConfigs, const binding::Bindings &bindings,
+    const Config &appConfig) {
+  if (appConfig.forcedWaveformBufferSize) {
+    return *appConfig.forcedWaveformBufferSize;
+  }
+
+  auto magnitudeForcedEnabled{appConfig.magnitudesForceMode &&
+                              *appConfig.magnitudesForceMode};
+  auto amplitudeForcedDisabled{
+      (appConfig.amplitudesForceMode && !*appConfig.amplitudesForceMode) &&
+      !magnitudeForcedEnabled};
+
+  if (amplitudeForcedDisabled) {
+    return Core::TimeSpan{};
+  }
+
+  throw Application::ConfigError{
+      "missing waveform buffer size; computing the size automatically is "
+      "currently not implemented"};
+
+  // TODO(damb): use both the template configurations and the bindings and
+  // compute the waveform buffer size.
+}
+
 bool Application::isEventDatabaseEnabled() const {
   return _config.urlEventDb.empty();
 }
@@ -1930,6 +1970,12 @@ void Application::Config::init(const Client::Application *app) {
   try {
     streamConfig.templateConfig.wfEnd =
         app->configGetDouble("template.waveformEnd");
+  } catch (...) {
+  }
+
+  try {
+    forcedWaveformBufferSize =
+        Core::TimeSpan{app->configGetDouble("processing.waveformBufferSize")};
   } catch (...) {
   }
 

--- a/src/apps/cc/app.cpp
+++ b/src/apps/cc/app.cpp
@@ -1787,7 +1787,7 @@ void Application::registerTimeWindowProcessor(
 
   for (const auto &waveformStreamId : waveformStreamIds) {
     _timeWindowProcessors.emplace(waveformStreamId, processor);
-    SCDETECT_LOG_DEBUG("[%s] Added time window processor with id: %s",
+    SCDETECT_LOG_DEBUG("[%s] Added time window processor: id=%s",
                        waveformStreamId.c_str(), processor->id().c_str());
     SCDETECT_LOG_DEBUG("Current time window processor count: %lu",
                        _timeWindowProcessors.size());
@@ -1850,8 +1850,13 @@ void Application::removeTimeWindowProcessor(
     auto it{range.first};
     while (it != range.second) {
       if (it->second == processor) {
-        SCDETECT_LOG_DEBUG("[%s] Removed time window processor with id: %s",
-                           waveformStreamId.c_str(), processor->id().c_str());
+        logging::TaggedMessage msg{
+            waveformStreamId,
+            "Removing time window processor: id=" + processor->id() +
+                ", status=" +
+                std::to_string(util::asInteger(processor->status())) +
+                ", status_value=" + std::to_string(processor->statusValue())};
+        SCDETECT_LOG_DEBUG("%s", logging::to_string(msg).c_str());
         it = _timeWindowProcessors.erase(it);
         SCDETECT_LOG_DEBUG("Current time window processor count: %lu",
                            _timeWindowProcessors.size());
@@ -1886,8 +1891,8 @@ void Application::registerDetection(
 
   for (const auto &waveformStreamId : waveformStreamIds) {
     _detections.emplace(waveformStreamId, detection);
-    SCDETECT_LOG_DEBUG("[%s] Added detection with id: %s",
-                       waveformStreamId.c_str(), detection->id().c_str());
+    SCDETECT_LOG_DEBUG("[%s] Added detection: id= %s", waveformStreamId.c_str(),
+                       detection->id().c_str());
     SCDETECT_LOG_DEBUG("Current detection count: %lu", _detections.size());
   }
 }
@@ -1906,7 +1911,7 @@ void Application::removeDetection(
     auto it{range.first};
     while (it != range.second) {
       if (it->second == detection) {
-        SCDETECT_LOG_DEBUG("[%s] Removed detection with id: %s",
+        SCDETECT_LOG_DEBUG("[%s] Removed detection: id=%s",
                            waveformStreamId.c_str(), detection->id().c_str());
         it = _detections.erase(it);
         SCDETECT_LOG_DEBUG("Current detection count: %lu", _detections.size());

--- a/src/apps/cc/app.cpp
+++ b/src/apps/cc/app.cpp
@@ -581,7 +581,9 @@ void Application::handleRecord(Record *rec) {
 
   if (!rec || !rec->data()) return;
 
-  if (!_waveformBuffer.feed(rec)) return;
+  bool waveformBufferingEnabled{_config.forcedWaveformBufferSize.value_or(
+                                    Core::TimeSpan{0.0}) > Core::TimeSpan{0.0}};
+  if (waveformBufferingEnabled && !_waveformBuffer.feed(rec)) return;
 
   auto detectorRange{_detectors.equal_range(std::string{rec->streamID()})};
   for (auto it = detectorRange.first; it != detectorRange.second; ++it) {

--- a/src/apps/cc/app.h
+++ b/src/apps/cc/app.h
@@ -84,6 +84,10 @@ class Application : public Client::StreamApplication {
     // detector configuration level granularity.
     boost::optional<bool> magnitudesForceMode;
 
+    // Flag with forces the waveform buffer size
+    boost::optional<Core::TimeSpan> forcedWaveformBufferSize{
+        Core::TimeSpan{300.0}};
+
     // Defines if a detector should be initialized although template
     // processors could not be initialized due to missing waveform data.
     // XXX(damb): For the time being, this configuration parameter is not
@@ -294,6 +298,10 @@ class Application : public Client::StreamApplication {
                                    const binding::Bindings &bindings,
                                    const Config &appConfig);
 
+  static Core::TimeSpan computeWaveformBufferSize(
+      const TemplateConfigs &templateConfigs, const binding::Bindings &bindings,
+      const Config &appConfig);
+
   bool isEventDatabaseEnabled() const;
 
   // Load events either from `eventDb` or `db`
@@ -373,7 +381,7 @@ class Application : public Client::StreamApplication {
   DetectorMap _detectors;
 
   // Ringbuffer
-  Processing::StreamBuffer _waveformBuffer{30 * 60 /*seconds*/};
+  Processing::StreamBuffer _waveformBuffer;
 
   using Detections =
       std::unordered_multimap<WaveformStreamId, std::shared_ptr<DetectionItem>>;

--- a/src/apps/cc/descriptions/scdetect-cc.xml
+++ b/src/apps/cc/descriptions/scdetect-cc.xml
@@ -73,6 +73,19 @@
             reset.
           </description>
         </parameter>
+        <parameter name="waveformBufferSize" type="double" default="300.0"
+                   unit="s">
+          <description>
+            Defines the waveform ringbuffer size in seconds. Buffering waveform
+            is required for amplitude calculation. The buffer's size must cover
+            the time window required for amplitude calculation. This may vary
+            from amplitude processor implementation to amplitude processor
+            implementation. Additionally, it depends on the configuration, too.
+            If amplitudes are not going to be calculated buffering records is
+            not required at all and therefore can be disabled by means of
+            setting the value to 0.
+          </description>
+        </parameter>
       </group>
       <group name="detector">
         <parameter name="timeCorrection" type="double" default="0"

--- a/src/apps/cc/reducing_amplitude_processor.cpp
+++ b/src/apps/cc/reducing_amplitude_processor.cpp
@@ -248,7 +248,7 @@ void ReducingAmplitudeProcessor::process(StreamState &streamState,
   amplitude->time.reference = signalStartTime;
   amplitude->time.end = static_cast<double>(signalEndTime - signalStartTime);
 
-  setStatus(Status::kFinished, 100);
+  setStatus(Status::kFinished, 100.0);
   emitAmplitude(record, amplitude);
 }
 

--- a/src/apps/cc/reducing_amplitude_processor.cpp
+++ b/src/apps/cc/reducing_amplitude_processor.cpp
@@ -269,6 +269,7 @@ bool ReducingAmplitudeProcessor::store(const Record *record) {
   if (!record->timeWindow().overlaps(safetyTimeWindow()) ||
       (isFirstStreamRecord &&
        (record->timeWindow().startTime() > safetyTimeWindow().startTime()))) {
+    setStatus(Status::kTerminated, 0.0);
     return false;
   }
 

--- a/src/apps/cc/test/reducing_amplitude_processor.cpp
+++ b/src/apps/cc/test/reducing_amplitude_processor.cpp
@@ -288,7 +288,7 @@ class TestReducingAmplitudeProcessor : public ReducingAmplitudeProcessor {
 
 // samples for parameterized testing
 using Samples = std::vector<ds::Sample>;
-Samples dataset{
+const Samples dataset{
     {/*description=*/"single stream, single record (constant sample values)",
      /*validatorCallback=*/
      [](const AmplitudeProcessor *proc, const Record *record,


### PR DESCRIPTION
**Features and Changes**:
- Allow to configure the waveform buffer size (in accordance with `scautopick`'s `ringBufferSize` configuration parameter); currently `scdetect-cc` does not compute the buffer size by itself - this may be implemented in future.
- Note that in case the buffer size is too small amplitude calculation (and therefore magnitude calculation, too) fails.
- Correctly handle failing amplitude processors.

Closes #81.