### PR TITLE
Fix `MRelative` magnitude calculation

### DIFF
--- a/src/apps/cc/amplitude/ratio.cpp
+++ b/src/apps/cc/amplitude/ratio.cpp
@@ -77,16 +77,17 @@ void RatioAmplitude::process(
     return;
   }
 
-  double ratio{0};
-  const auto templateWaveformAbsMax{
-      DoubleArray::ConstCast(_templateWaveform.waveform().data())->absMax()};
-
-  if (0 != templateWaveformAbsMax) {
-    const auto dataAbsMax{_buffer.absMax()};
-    ratio = dataAbsMax / templateWaveformAbsMax;
+  const auto templateWaveformAbsMax{std::abs(
+      DoubleArray::ConstCast(_templateWaveform.waveform().data())->absMax())};
+  if (templateWaveformAbsMax == 0) {
+    setStatus(Status::kError, 0);
+    return;
   }
 
   auto amplitude{util::make_smart<Amplitude>()};
+
+  const auto dataAbsMax{std::abs(_buffer.absMax())};
+  const auto ratio{dataAbsMax / templateWaveformAbsMax};
   amplitude->value.value = ratio;
 
   // time window based amplitude time

--- a/src/apps/cc/magnitude/mrelative.cpp
+++ b/src/apps/cc/magnitude/mrelative.cpp
@@ -28,8 +28,10 @@ double MRelative::computeMagnitude(const DataModel::Amplitude* amplitude) {
   assert(amplitude);
   assert(_templateMagnitude);
 
-  return _templateMagnitude->magnitude().value() +
-         std::log10(amplitude->amplitude().value());
+  const auto amplitudeValue{amplitude->amplitude().value()};
+  assert((std::isfinite(amplitudeValue) && amplitudeValue > 0));
+
+  return _templateMagnitude->magnitude().value() + std::log10(amplitudeValue);
 }
 
 }  // namespace magnitude


### PR DESCRIPTION
**Bugfixes**:
- compute absolute values client-side; the bug was caused due to a misunderstanding of SeisComP API of `NumericArray<T>::absMax()` (see https://github.com/SeisComP/common/blob/399d98c2d709f24ecf0f4bc27f759cefa76dc2f3/libs/seiscomp/core/typedarray.cpp#L425-L428)

Thanks  @mmesim for spotting this.