### PR TITLE
Fix issues reported by #97

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,12 @@ detection arrives within this period, the previous one is not used, anymore.
   detection once the detector is triggered. Note that the configured value is
   only taken into account if trigger facilities are enabled.
 
+> **NOTE**: With trigger facilities enabled a detection is processed only once
+> there is the *next* detection already available. Since processing a detection
+> may involve calculating amplitudes the `processing.waveformBufferSize` must
+> cover the corresponding duration in order to successfully compute amplitudes
+> (fetching historical data is currently not implemented, yet).
+
 #### Stream configuration parameters
 
 A stream set must contain at least a single stream configuration. For a
@@ -494,8 +500,13 @@ In general, the computation of amplitudes is sensor location dependent. In order
 to provide dedicated configuration for different sensor locations `scdetect-cc`
 makes use of
 SeisComP's [bindings configuration](https://www.seiscomp.de/doc/base/concepts/configuration.html#bindings-configuration)
-concept. Note that amplitudes are calculated only for those sensor locations
-with bindings configuration available.
+concept. Note that amplitudes are calculated only:
+
+- for those sensor locations with bindings configuration available,
+- if the internal waveform buffer still contains the required time window.
+
+The waveform buffer size may be configured using
+the `processing.waveformBufferSize` module configuration parameter.
 
 #### Bindings configuration
 

--- a/src/apps/cc/app.cpp
+++ b/src/apps/cc/app.cpp
@@ -607,7 +607,7 @@ void Application::handleRecord(Record *rec) {
     auto range{_timeWindowProcessors.equal_range(rec->streamID())};
     for (auto it = range.first; it != range.second; ++it) {
       const auto &proc{it->second};
-      // the amplitude processor must not be already on the removal list
+      // the time window processor must not be already on the removal list
       if (std::find_if(
               std::begin(_timeWindowProcessorRemovalQueue),
               std::end(_timeWindowProcessorRemovalQueue),
@@ -618,7 +618,7 @@ void Application::handleRecord(Record *rec) {
         continue;
       }
 
-      // schedule the amplitude processor for deletion when finished
+      // schedule the time window processor for deletion when finished
       if (it->second->finished()) {
         removeTimeWindowProcessor(it->second);
       } else {
@@ -631,7 +631,7 @@ void Application::handleRecord(Record *rec) {
 
     _timeWindowProcessorRegistrationBlocked = false;
 
-    // remove outdated amplitude processors
+    // remove outdated time window processors
     while (!_timeWindowProcessorRemovalQueue.empty()) {
       const auto processor{
           _timeWindowProcessorRemovalQueue.front().timeWindowProcessor};
@@ -639,7 +639,7 @@ void Application::handleRecord(Record *rec) {
       removeTimeWindowProcessor(processor);
     }
 
-    // register pending amplitude processors
+    // register pending time window processors
     while (!_timeWindowProcessorRegistrationQueue.empty()) {
       const auto &timeWindowProcessorQueueItem{
           _timeWindowProcessorRegistrationQueue.front()};

--- a/src/apps/cc/app.cpp
+++ b/src/apps/cc/app.cpp
@@ -503,9 +503,10 @@ void Application::done() {
     }
 
     // flush pending detections
-    for (auto &detectionPair : _detections) {
-      publishAndRemoveDetection(detectionPair.second);
+    for (const auto &detectionPair : _detections) {
+      publishDetection(detectionPair.second);
     }
+    _detections.clear();
 
     if (_ep) {
       IO::XMLArchive ar;
@@ -934,6 +935,15 @@ void Application::processDetection(
     initAmplitudeProcessors(detectionItemPtr, *processor);
   } else {
     publishDetection(detectionItem);
+  }
+}
+
+void Application::publishDetection(
+    const std::shared_ptr<DetectionItem> &detection) {
+  if (!detection->published) {
+    publishDetection(*detection);
+
+    detection->published = true;
   }
 }
 
@@ -1743,12 +1753,7 @@ bool Application::initAmplitudeProcessors(
 
 void Application::publishAndRemoveDetection(
     std::shared_ptr<DetectionItem> &detection) {
-  if (!detection->published) {
-    publishDetection(*detection);
-
-    detection->published = true;
-  }
-
+  publishDetection(detection);
   removeDetection(detection);
 }
 

--- a/src/apps/cc/app.h
+++ b/src/apps/cc/app.h
@@ -370,6 +370,7 @@ class Application : public Client::StreamApplication {
       const detector::Detector *processor, const Record *record,
       std::unique_ptr<const detector::Detector::Detection> detection);
 
+  void publishDetection(const std::shared_ptr<DetectionItem> &detection);
   void publishDetection(const DetectionItem &detectionItem);
 
   void publishAndRemoveDetection(std::shared_ptr<DetectionItem> &detection);

--- a/src/apps/cc/combining_amplitude_processor.cpp
+++ b/src/apps/cc/combining_amplitude_processor.cpp
@@ -106,8 +106,11 @@ bool CombiningAmplitudeProcessor::store(const Record *record) {
 
       logging::TaggedMessage msg{
           record->streamID(),
-          "Failed to feed data (tw.start=" + record->startTime().iso() +
-              ", tw.end=" + record->endTime().iso() + "). Reason: status=" +
+          "Failed to feed data (rec.tw.start=" + record->startTime().iso() +
+              ", rec.tw.end=" + record->endTime().iso() +
+              ", proc.tw.start=" + safetyTimeWindow().startTime().iso() +
+              ", proc.tw.end=" + safetyTimeWindow().endTime().iso() +
+              "). Reason: status=" +
               std::to_string(util::asInteger(processor->status())) +
               ", status_value=" + std::to_string(processor->statusValue()) +
               " (" + e.what() + ")"};


### PR DESCRIPTION
**Bugfixes**:
- Fix memory issue when flushing pending detections

**Features and Changes**:
- Handle amplitude processor errors caused by missing buffered data more gracefully (i.e. report a warning instead of an error). Note that at the time being, fetching historical data is not implemented, yet.

Closes #97.